### PR TITLE
Add universal variables to semantic correctness spec

### DIFF
--- a/language/sygus.tex
+++ b/language/sygus.tex
@@ -547,8 +547,8 @@ information:
 $f_1, \ldots, f_n$, which we refer to
 as the current list of \emph{functions to synthesize},
 \item A list 
-$x_1, \ldots, x_m$ of variables, 
-which we refer to the current list of \emph{universal variables}, 
+$v_1, \ldots, v_m$ of variables, 
+which we refer to as the current list of \emph{universal variables},
 \item A list of formulas
 $\varphi_1, \ldots, \varphi_p$,
 which we refer to as the current list of \emph{constraints},
@@ -1596,7 +1596,8 @@ A tuple of functions
 $( \lambda X_1.\, t_1, \ldots, \lambda X_n.\, t_n )$
 satisfies the syntactic restrictions
 for functions-to-synthesize $( f_1, \ldots, f_n )$
-in conjecture $\exists f_1, \ldots, f_n.\, \varphi$
+in conjecture $\exists f_1, \ldots, f_n.\,\forall v_1, \ldots,
+v_m.\ \varphi$
 if $\lambda X_i.\, t_i$
 satisfies the syntactic specification for $f_i$
 for each $i=1,\ldots,n$.
@@ -1616,8 +1617,10 @@ A tuple of functions
 $( \lambda X_1.\, t_1, \ldots, \lambda X_n.\, t_n)$
 satisfies the semantic restrictions
 for functions-to-synthesize $( f_1, \ldots, f_n )$
-in conjecture $\exists f_1, \ldots, f_n.\,  \varphi$ in background theory $T$
-if $\varphi$ is $T$-valid formula
+in conjecture $\exists f_1, \ldots, f_n.\,\forall v_1, \ldots,
+v_m.  \varphi$ in background theory $T$
+if $\forall v_1, \ldots,
+v_m.\, \varphi$ is $T$-valid formula
 when $f_1, \ldots, f_n$ are defined to be terms
 whose semantics are given by the functions
 $\lambda X_1.\, t_1, \ldots, \lambda X_n.\, t_n$.


### PR DESCRIPTION
I think the correctness specification needs to include the universal vars, because \varphi is specified to be a quantifier free formula here: https://github.com/SyGuS-Org/docs/blob/6c71255f345d80080b6091b762a99c61c6b2df22/language/introduction.tex#L24

And in the introduction it states that the objective then is to find definitions $e_i$ (in the form of
expression bodies) for each function $f_i$ such that ...t he constraint 
$\forall v_1, v_2, \ldots, v_m.\ \varphi$ is valid in the background theory
under the assumption that functions $f_1, \ldots, f_n$ are interpreted as functions returning $e_1, \ldots, e_n$.
https://github.com/SyGuS-Org/docs/blob/6c71255f345d80080b6091b762a99c61c6b2df22/language/introduction.tex#L34-L36


I also made the universal variables consistently v, as they were sometimes referred to with v or x.