### PR TITLE
Small fix for string example grammar

### DIFF
--- a/language/sygus.tex
+++ b/language/sygus.tex
@@ -3066,8 +3066,8 @@ have been omitted from the grammar below for the sake of brevity.
                   (str.from_int y_int)
                   (str.from_code y_int)
                   (ite y_bool y_str y_str)))
-    (y_rl RegLan ((Constant String)
-                  (Variable String)
+    (y_rl RegLan ((Constant RegLan)
+                  (Variable RegLan)
                   re.none
                   re.all
                   re.allchar


### PR DESCRIPTION
String constants and variables shouldn't be valid regexes by default, right?

Since we have `(str.to_re y_str)` rule for the `y_rl` nonterminal, I think string constants and variables are properly handled already.

Should we have `(Constant RegLan)` and `(Variable RegLan)` rules though? I think they make sense.